### PR TITLE
Move correlation context instantiation from "Init" to "Run".

### DIFF
--- a/onlinescoring/score_datacollector.py
+++ b/onlinescoring/score_datacollector.py
@@ -18,7 +18,6 @@ def init():
     global inputs_collector, outputs_collector, artificial_context
     inputs_collector = Collector(name='model_inputs')          
     outputs_collector = Collector(name='model_outputs')
-    artificial_context = BasicCorrelationContext(id='Laziz_Demo')
     print("========================================")
     print("--Initialised data collector variables--")
     print("========================================")
@@ -41,6 +40,8 @@ def run(raw_data):
     method and return the result back
     """
     logging.info("Request received")
+    #Create a correlation context with unique ID. This constructor is also accountable for picking the current timestamp that will be associated to query in logging.
+    artificial_context = BasicCorrelationContext()
     data = json.loads(raw_data)["data"]
     data = numpy.array(data)
 


### PR DESCRIPTION
Move correlation context from Init to Run.

If put in "init" it will result on same timestamp from init time being reused for all incoming queries.
In turn this means all log entries go to the same log file in blobcontainer under same folder modelDataCollector/endpoint-data-collector//model_outputs/year/month/day/hour
This will completely break Model Monitoring that expects to find logs for each past few days in their own folders.

Also using a string to instantiate the Context will prevent a GUID from being used, using the static string instead for all queries. This prevents correlation between input and outputs by Model Monitoring logic (that should take place thanks the the uniqueID generated at "run" time).

Therefore also removed the static string from constructor call.